### PR TITLE
`QueryType` cast and clone methods

### DIFF
--- a/.changeset/lazy-cherries-flash.md
+++ b/.changeset/lazy-cherries-flash.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/db': patch
+---
+
+Fix `QueryType` in `journeyapps/db` cast and clone methods

--- a/journeyapps-db/src/types/QueryType.ts
+++ b/journeyapps-db/src/types/QueryType.ts
@@ -1,14 +1,30 @@
 import { QueryType as SchemaQueryType, QueryTypeFactory as SchemaQueryTypeFactory } from '@journeyapps/parser-schema';
 import { Query } from '../query/Query';
+import { ObjectType } from './ObjectType';
 import { DBTypeMixin } from './Type';
 
 export class QueryType extends DBTypeMixin(SchemaQueryType) {
-  clone(query: Query) {
-    return this.objectType.clone(query);
+  // This might look very similar to ObjectType, but here we are checking value.fetch instead of value.save.
+  cast(value: any) {
+    if (typeof value != 'object') {
+      throw new Error(value + ' is not an object');
+    }
+    const thisTypeName = this.objectType.name;
+    if (
+      value.type != null &&
+      value.type instanceof ObjectType &&
+      value.type.name == thisTypeName &&
+      typeof value._fetch == 'function'
+    ) {
+      return value;
+    } else {
+      // We do not print the value here, since it may be a massive array.
+      throw new Error('Expected value to have query type ' + thisTypeName);
+    }
   }
 
-  cast(value: any): any {
-    return this.objectType.cast(value);
+  clone(value: Query) {
+    return value._clone();
   }
 }
 


### PR DESCRIPTION
Fix `QueryType` in `@journeyapps/db`, `cast` and `clone` methods.

These changes were rolled back in the previous PR [See diff](https://github.com/journeyapps-platform/journey-lib/pull/11/commits/b046bdbae5bdb1b1c12f6b665a47e6603dfa4b2e#diff-84bf8f893127aab728dff930a231bc40862c623dbc7d798f6e62bc8647518ab7) but this is actually needed