### PR TITLE
[Chore] Add the `transform-value` view `param` attribute

### DIFF
--- a/.changeset/tidy-seals-shout.md
+++ b/.changeset/tidy-seals-shout.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/parser-schema': patch
+---
+
+Added transform-value to param parser definition

--- a/.changeset/tidy-seals-shout.md
+++ b/.changeset/tidy-seals-shout.md
@@ -2,4 +2,4 @@
 '@journeyapps/parser-schema': patch
 ---
 
-Added transform-value to param parser definition
+Add `transform-value` to param parser definition

--- a/journeyapps-parser-schema/src/schema/schemaParser.ts
+++ b/journeyapps-parser-schema/src/schema/schemaParser.ts
@@ -1,6 +1,6 @@
 // # schema module
 // Parser for v2 and v3 of the schema XML.
-import { FormatString } from '@journeyapps/evaluator';
+import { FormatString, FunctionTokenExpression } from '@journeyapps/evaluator';
 import * as xml from '@journeyapps/core-xml';
 import { Schema } from './Schema';
 import { ObjectType } from '../types/ObjectType';
@@ -123,6 +123,7 @@ const v3ParameterDef = {
     "media must be 'any', or one of the specific allowed mime types."
   ),
   required: xml.attribute.optionList(['true', 'false']),
+  'transform-value': xml.attribute.optionListWithFunctions([], FunctionTokenExpression.PREFIX),
   _required: ['name', 'type']
 };
 


### PR DESCRIPTION
## Description
This pr defines the `transform-value` `<param />` attribute so that oxide does not flag it as invalid.

## Checklist
 - [x] Clubhouse ticket [ch12166](https://app.shortcut.com/journeyapps/story/12166)
 - [x] Related Oxide pr https://github.com/journeyapps-platform/ide/pull/875