### PR TITLE
[Hotfix] Broken serialization `single-choice` and `single-choice-integer` types

### DIFF
--- a/.changeset/wise-ladybugs-jump.md
+++ b/.changeset/wise-ladybugs-jump.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/db': patch
+---
+
+Fix `single-choice` and `single-choice-integer` types, serialization methods `valueToJSON` and `valueFromJSON`

--- a/journeyapps-db/src/types/primitives/SingleChoice.ts
+++ b/journeyapps-db/src/types/primitives/SingleChoice.ts
@@ -4,22 +4,6 @@ import { DBTypeMixin } from '../Type';
 export class SingleChoiceType extends DBTypeMixin(SchemaSingleChoiceType) {
   static DEFAULT_INVALID_VALUE = '< invalid value >';
 
-  valueToJSON(value: any) {
-    if (typeof value == 'number') {
-      return value;
-    } else {
-      return null;
-    }
-  }
-
-  valueFromJSON(value: any) {
-    if (typeof value == 'number') {
-      return value;
-    } else {
-      return null;
-    }
-  }
-
   format(value: any): string {
     const option = this.options[value];
     if (option == null) {

--- a/journeyapps-db/src/types/primitives/SingleChoiceInteger.ts
+++ b/journeyapps-db/src/types/primitives/SingleChoiceInteger.ts
@@ -3,6 +3,23 @@ import { DBTypeMixin } from '../Type';
 
 export class SingleChoiceIntegerType extends DBTypeMixin(SchemaSingleChoiceIntegerType) {
   static DEFAULT_INVALID_VALUE = '< invalid value >';
+
+  valueToJSON(value: any) {
+    if (typeof value == 'number') {
+      return value;
+    } else {
+      return null;
+    }
+  }
+
+  valueFromJSON(value: any) {
+    if (typeof value == 'number') {
+      return value;
+    } else {
+      return null;
+    }
+  }
+
   format(value: any): string {
     const option = this.options[value];
     if (option == null) {


### PR DESCRIPTION
PEBKAC mixed up `single-choice` and `single-choice-integer` adding `valueToJSON` and `valueFromJSON` to the wrong class. This caused `single-choice` to not save correctly

## Checklist
- [x] Tested on local dev using dev versions