### PR TITLE
[Fix] Regression with `date` and `datetime` display format

### DIFF
--- a/.changeset/moody-papayas-attend.md
+++ b/.changeset/moody-papayas-attend.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/db': patch
+---
+
+Fix display format for `date` and `datetime`,where it would not use the fallback value when set to `null`

--- a/journeyapps-db/src/types/primitives/Date.ts
+++ b/journeyapps-db/src/types/primitives/Date.ts
@@ -41,13 +41,13 @@ export class DateType extends DBTypeMixin(SchemaDateType) {
     }
   }
 
-  format(value: any, format: string = DateType.DEFAULT_FORMAT) {
+  format(value: any, format?: string) {
     // Works for Date and Day objects.
     if (Day.isDay(value)) {
       value = value.toDate();
     }
     const d = moment(value).utc();
-    return d.format(format);
+    return d.format(format ?? DateType.DEFAULT_FORMAT);
   }
 
   cast(value: any) {

--- a/journeyapps-db/src/types/primitives/Datetime.ts
+++ b/journeyapps-db/src/types/primitives/Datetime.ts
@@ -26,8 +26,8 @@ export class DatetimeType extends DBTypeMixin(SchemaDatetimeType) {
     }
   }
 
-  format(value: any, format: string = DatetimeType.DEFAULT_FORMAT): string {
-    return moment(value).format(format);
+  format(value: any, format?: string): string {
+    return moment(value).format(format ?? DatetimeType.DEFAULT_FORMAT);
   }
 
   cast(value: any): any {


### PR DESCRIPTION
[ch12679](https://app.shortcut.com/journeyapps/story/12679)

Display format for `date` and `datetime` would not use fallback value when set to `null`