### PR TITLE
[Feature] Add support for parsing properties of `MemberExpression`

### DIFF
--- a/.changeset/pretty-dots-repeat.md
+++ b/.changeset/pretty-dots-repeat.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/evaluator': patch
+---
+
+Improve `ShorthandTokenExpression` to also parse properties, i.e. object.property1, object['property2']. Added `isComputed` to `TokenExpression` options

--- a/journeyapps-evaluator/src/parsers/BlockStatementParser.ts
+++ b/journeyapps-evaluator/src/parsers/BlockStatementParser.ts
@@ -1,5 +1,6 @@
 import { Node, BlockStatement, isLabeledStatement, isExpressionStatement, isBlockStatement } from '@babel/types';
 import { FormatStringContext } from '../context/FormatStringContext';
+import { FunctionExpressionContext } from '../context/FunctionExpressionContext';
 import { ConstantTokenExpression } from '../token-expressions';
 import {
   AbstractExpressionParser,
@@ -23,7 +24,7 @@ export class BlockStatementParser extends AbstractExpressionParser<BlockStatemen
     if (isLabeledStatement(body)) {
       const { body: child } = body;
       child.extra = { ...child.extra, parent: node };
-      return parseNode({ ...event, node: child });
+      return parseNode({ ...event, node: child, context: new FunctionExpressionContext() });
     }
     // Example `{item.price}`
     if (isExpressionStatement(body)) {

--- a/journeyapps-evaluator/src/parsers/MemberExpressionParser.ts
+++ b/journeyapps-evaluator/src/parsers/MemberExpressionParser.ts
@@ -18,6 +18,13 @@ export type MemberExpressionParsedType =
   | ShorthandTokenExpression
   | FormatShorthandTokenExpression;
 
+/**
+ * Parses member expressions like:
+ *
+ * object.property1
+ * object[param].property2
+ * object['property1'].property2
+ */
 export class MemberExpressionParser extends AbstractExpressionParser<MemberExpression, MemberExpressionParsedType> {
   parse(event: ExpressionNodeParseEvent<MemberExpression>) {
     const { node, source, context } = event;

--- a/journeyapps-evaluator/src/parsers/MemberExpressionParser.ts
+++ b/journeyapps-evaluator/src/parsers/MemberExpressionParser.ts
@@ -1,9 +1,11 @@
-import { MemberExpression } from '@babel/types';
+import { MemberExpression, isIdentifier } from '@babel/types';
 import { FunctionExpressionContext } from '../context/FunctionExpressionContext';
 import {
   FormatShorthandTokenExpression,
   FunctionTokenExpression,
-  ShorthandTokenExpression
+  ShorthandTokenExpression,
+  ShorthandTokenExpressionOptions,
+  TokenExpression
 } from '../token-expressions';
 import {
   AbstractExpressionParser,
@@ -21,13 +23,50 @@ export class MemberExpressionParser extends AbstractExpressionParser<MemberExpre
     const { node, source, context } = event;
     const expr = source.slice(node.start, node.end);
 
+    const { objectName, properties } = MemberExpressionParser.parseMember(event);
+
+    const options: ShorthandTokenExpressionOptions = {
+      expression: expr,
+      name: objectName,
+      properties: properties
+    };
+
     if (FunctionExpressionContext.isInstanceOf(context)) {
-      return new FunctionTokenExpression({ expression: expr });
+      return new ShorthandTokenExpression({ ...options, isFunction: true });
     }
+
     const format: string = node.extra?.format as string;
-    return format != null
-      ? new FormatShorthandTokenExpression({ expression: expr, format: format })
-      : new ShorthandTokenExpression({ expression: expr });
+    return format == null
+      ? new ShorthandTokenExpression(options)
+      : new FormatShorthandTokenExpression({ ...options, format: format });
+  }
+
+  static parseMember(
+    event: ExpressionNodeParseEvent<MemberExpression>,
+    properties: TokenExpression[] = []
+  ): {
+    objectName: string;
+    properties: TokenExpression[];
+  } {
+    const { node, source, parseNode } = event;
+    if (isIdentifier(node.object)) {
+      const propertyExpr = parseNode({
+        node: node.property,
+        source: source.slice(node.property.start, node.property.end)
+      });
+      propertyExpr.options.isComputed = node.computed;
+      properties.push(propertyExpr);
+      return {
+        objectName: node.object.name,
+        properties: properties
+      };
+    }
+
+    const result = MemberExpressionParser.parseMember({ ...event, node: node.object as MemberExpression }, properties);
+    result.properties.push(
+      parseNode({ node: node.property, source: source.slice(node.property.start, node.property.end) })
+    );
+    return result;
   }
 }
 

--- a/journeyapps-evaluator/src/parsers/MemberExpressionParser.ts
+++ b/journeyapps-evaluator/src/parsers/MemberExpressionParser.ts
@@ -39,7 +39,10 @@ export class MemberExpressionParser extends AbstractExpressionParser<MemberExpre
     };
 
     if (FunctionExpressionContext.isInstanceOf(context)) {
-      return new ShorthandTokenExpression({ ...options, isFunction: true });
+      const newExpression = !FunctionTokenExpression.hasPrefix(expr)
+        ? `${FunctionTokenExpression.PREFIX}${expr}`
+        : expr;
+      return new ShorthandTokenExpression({ ...options, expression: newExpression, isFunction: true });
     }
 
     const format: string = node.extra?.format as string;

--- a/journeyapps-evaluator/src/parsers/MemberExpressionParser.ts
+++ b/journeyapps-evaluator/src/parsers/MemberExpressionParser.ts
@@ -39,10 +39,7 @@ export class MemberExpressionParser extends AbstractExpressionParser<MemberExpre
     };
 
     if (FunctionExpressionContext.isInstanceOf(context)) {
-      const newExpression = !FunctionTokenExpression.hasPrefix(expr)
-        ? `${FunctionTokenExpression.PREFIX}${expr}`
-        : expr;
-      return new ShorthandTokenExpression({ ...options, expression: newExpression, isFunction: true });
+      return new FunctionTokenExpression(options);
     }
 
     const format: string = node.extra?.format as string;

--- a/journeyapps-evaluator/src/parsers/MemberExpressionParser.ts
+++ b/journeyapps-evaluator/src/parsers/MemberExpressionParser.ts
@@ -70,9 +70,12 @@ export class MemberExpressionParser extends AbstractExpressionParser<MemberExpre
     }
 
     const result = MemberExpressionParser.parseMember({ ...event, node: node.object as MemberExpression }, properties);
-    result.properties.push(
-      parseNode({ node: node.property, source: source.slice(node.property.start, node.property.end) })
-    );
+    const propertyExpr = parseNode({
+      node: node.property,
+      source: source.slice(node.property.start, node.property.end)
+    });
+    propertyExpr.options.isComputed = node.computed;
+    result.properties.push(propertyExpr);
     return result;
   }
 }

--- a/journeyapps-evaluator/src/token-expressions/TokenExpression.ts
+++ b/journeyapps-evaluator/src/token-expressions/TokenExpression.ts
@@ -2,7 +2,6 @@ import { FormatStringScope } from '../definitions/FormatStringScope';
 
 export interface TokenExpressionOptions {
   expression: string;
-
   start?: number;
   format?: string;
   isPrimitive?: boolean;
@@ -12,6 +11,7 @@ export interface TokenExpressionOptions {
    * If the token expression is a function that needs to be called or not.
    */
   isFunction?: boolean;
+  isComputed?: boolean;
 }
 
 export abstract class TokenExpression<O extends TokenExpressionOptions = TokenExpressionOptions, V extends any = any> {
@@ -25,7 +25,14 @@ export abstract class TokenExpression<O extends TokenExpressionOptions = TokenEx
       throw new Error('Cannot instantiate abstract TokenExpression class!');
     }
     this.type = type;
-    this.options = { isPrimitive: false, isConstant: false, isShorthand: false, isFunction: false, ...options };
+    this.options = {
+      isPrimitive: false,
+      isConstant: false,
+      isShorthand: false,
+      isFunction: false,
+      isComputed: false,
+      ...options
+    };
     this.expression = this.options.expression;
     this.isPrimitive = this.options.isPrimitive;
   }

--- a/journeyapps-evaluator/src/token-expressions/function/FunctionTokenExpression.ts
+++ b/journeyapps-evaluator/src/token-expressions/function/FunctionTokenExpression.ts
@@ -7,6 +7,12 @@ import { FormatStringScope } from '../../definitions/FormatStringScope';
 export interface FunctionTokenExpressionOptions extends TokenExpressionOptions {
   name?: string;
   arguments?: TokenExpression[];
+
+  /**
+   * Used for non-call expressions to store properties.
+   * Example: `$:object.property` or `$:view.user['name']`
+   */
+  properties?: TokenExpression[];
 }
 
 export class FunctionTokenExpression<
@@ -73,11 +79,11 @@ export class FunctionTokenExpression<
   }
 
   stringify() {
-    if (!this.isCallExpression()) {
-      return this.expression;
+    if (this.isCallExpression()) {
+      const argStrings = this.arguments.map((arg) => arg.stringify());
+      return `${this.functionName()}(${argStrings.join(', ')})`;
     }
-    const argStrings = this.arguments.map((arg) => arg.stringify());
-    return `${this.functionName()}(${argStrings.join(', ')})`;
+    return this.expression;
   }
 
   clone(): this {

--- a/journeyapps-evaluator/src/token-expressions/shorthand/FormatShorthandTokenExpression.ts
+++ b/journeyapps-evaluator/src/token-expressions/shorthand/FormatShorthandTokenExpression.ts
@@ -1,10 +1,9 @@
 /**
  * Shorthand token expression with format specifier.
  */
-import { ShorthandTokenExpression } from './ShorthandTokenExpression';
-import { TokenExpressionOptions } from '../TokenExpression';
+import { ShorthandTokenExpression, ShorthandTokenExpressionOptions } from './ShorthandTokenExpression';
 
-export interface FormatShorthandTokenExpressionOptions extends TokenExpressionOptions {
+export interface FormatShorthandTokenExpressionOptions extends ShorthandTokenExpressionOptions {
   format: string;
 }
 

--- a/journeyapps-evaluator/src/token-expressions/shorthand/ShorthandTokenExpression.ts
+++ b/journeyapps-evaluator/src/token-expressions/shorthand/ShorthandTokenExpression.ts
@@ -5,6 +5,14 @@ import { TokenExpression, TokenExpressionOptions } from '../TokenExpression';
 
 /**
  * Shorthand token expression.
+ *
+ * <var name="my_user" type="user">
+ *
+ * <info value="{my_user.name}" />
+ *
+ * Above is a shorthand for
+ *
+ * <info value="{$:view.my_user.name}" />
  */
 
 export interface ShorthandTokenExpressionOptions extends TokenExpressionOptions {

--- a/journeyapps-evaluator/src/token-expressions/shorthand/ShorthandTokenExpression.ts
+++ b/journeyapps-evaluator/src/token-expressions/shorthand/ShorthandTokenExpression.ts
@@ -6,12 +6,18 @@ import { TokenExpression, TokenExpressionOptions } from '../TokenExpression';
 /**
  * Shorthand token expression.
  */
+
+export interface ShorthandTokenExpressionOptions extends TokenExpressionOptions {
+  name?: string;
+  properties?: TokenExpression[];
+}
+
 export class ShorthandTokenExpression<
-  O extends TokenExpressionOptions = TokenExpressionOptions
+  O extends ShorthandTokenExpressionOptions = ShorthandTokenExpressionOptions
 > extends TokenExpression<O> {
   static TYPE = 'shorthand-expression';
   constructor(options: O) {
-    super(ShorthandTokenExpression.TYPE, { ...options, isShorthand: true });
+    super(ShorthandTokenExpression.TYPE, { ...options, isShorthand: true, name: options.name ?? options.expression });
   }
 
   async tokenEvaluatePromise(scope: FormatStringScope) {

--- a/journeyapps-evaluator/tests/ExpressionParser.test.ts
+++ b/journeyapps-evaluator/tests/ExpressionParser.test.ts
@@ -75,6 +75,15 @@ describe('Expression Parsing ', () => {
       new ShorthandTokenExpression({ expression: 'field', isComputed: true })
     ]);
 
+    result = parser.parse<ShorthandTokenExpression>({ source: 'user.roles[field]' });
+    expect(result).toBeInstanceOf(ShorthandTokenExpression);
+    expect(result.expression).toEqual('user.roles[field]');
+    expect(result.options.name).toEqual('user');
+    expect(result.options.properties).toEqual([
+      new ShorthandTokenExpression({ expression: 'roles' }),
+      new ShorthandTokenExpression({ expression: 'field', isComputed: true })
+    ]);
+
     result = parser.parse<ShorthandTokenExpression>({ source: "user['name'].length" });
     expect(result).toBeInstanceOf(ShorthandTokenExpression);
     expect(result.expression).toEqual("user['name'].length");
@@ -82,6 +91,15 @@ describe('Expression Parsing ', () => {
     expect(result.options.properties).toEqual([
       new ConstantTokenExpression({ expression: 'name', isComputed: true }),
       new ShorthandTokenExpression({ expression: 'length' })
+    ]);
+
+    result = parser.parse<ShorthandTokenExpression>({ source: "user['roles']['admin']" });
+    expect(result).toBeInstanceOf(ShorthandTokenExpression);
+    expect(result.expression).toEqual("user['roles']['admin']");
+    expect(result.options.name).toEqual('user');
+    expect(result.options.properties).toEqual([
+      new ConstantTokenExpression({ expression: 'roles', isComputed: true }),
+      new ConstantTokenExpression({ expression: 'admin', isComputed: true })
     ]);
 
     result = parser.parse<ShorthandTokenExpression>({ source: "user.files['image'].filename.length" });

--- a/journeyapps-evaluator/tests/ExpressionParser.test.ts
+++ b/journeyapps-evaluator/tests/ExpressionParser.test.ts
@@ -130,14 +130,14 @@ describe('Expression Parsing ', () => {
 
     const result6 = parser.parse<ShorthandTokenExpression>({ source: '$:journey.version' });
     expect(result6).toBeInstanceOf(ShorthandTokenExpression);
-    expect(result6.expression).toEqual('journey.version');
+    expect(result6.expression).toEqual('$:journey.version');
     expect(result6.options.name).toEqual('journey');
     expect(result6.options.properties).toEqual([new ShorthandTokenExpression({ expression: 'version' })]);
-    expect(result6.stringify()).toEqual('journey.version');
+    expect(result6.stringify()).toEqual('$:journey.version');
 
     const result7 = parser.parse<ShorthandTokenExpression>({ source: "$:user['name'].length" });
     expect(result6).toBeInstanceOf(ShorthandTokenExpression);
-    expect(result7.expression).toEqual("user['name'].length");
+    expect(result7.expression).toEqual("$:user['name'].length");
     expect(result7.options.name).toEqual('user');
     expect(result7.options.properties).toEqual([
       new ConstantTokenExpression({ expression: 'name', isComputed: true }),

--- a/journeyapps-evaluator/tests/ExpressionParser.test.ts
+++ b/journeyapps-evaluator/tests/ExpressionParser.test.ts
@@ -108,54 +108,61 @@ describe('Expression Parsing ', () => {
   });
 
   it('should parse FunctionTokenExpression', ({ parser }) => {
-    const result1: any = parser.parse({ source: 'foo()' });
-    expect(result1).toBeInstanceOf(FunctionTokenExpression);
-    expect(result1.expression).toEqual('foo()');
+    let result: any = parser.parse({ source: 'foo()' });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual('foo()');
 
-    const result2 = parser.parse({ source: '$:foo()' });
-    expect(result2).toBeInstanceOf(FunctionTokenExpression);
-    expect(result2.expression).toEqual('foo()');
+    result = parser.parse({ source: '$:foo()' });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual('foo()');
 
-    const result3 = parser.parse({ source: '{$:foo()}' });
-    expect(result3).toBeInstanceOf(FunctionTokenExpression);
-    expect(result3.expression).toEqual('foo()');
+    result = parser.parse({ source: '{$:foo()}' });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual('foo()');
 
-    const result4 = parser.parse({ source: '$:myVar.foo()' });
-    expect(result4).toBeInstanceOf(FunctionTokenExpression);
-    expect(result4.expression).toEqual('myVar.foo()');
+    result = parser.parse({ source: '$:myVar.foo()' });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual('myVar.foo()');
 
-    const result5 = parser.parse({ source: '$:myVar' });
-    expect(result5).toBeInstanceOf(FunctionTokenExpression);
-    expect(result5.expression).toEqual('myVar');
+    result = parser.parse({ source: '$:myVar' });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual('myVar');
 
-    const result6 = parser.parse<ShorthandTokenExpression>({ source: '$:journey.version' });
-    expect(result6).toBeInstanceOf(ShorthandTokenExpression);
-    expect(result6.expression).toEqual('$:journey.version');
-    expect(result6.options.name).toEqual('journey');
-    expect(result6.options.properties).toEqual([new ShorthandTokenExpression({ expression: 'version' })]);
-    expect(result6.stringify()).toEqual('$:journey.version');
+    result = parser.parse({ source: '{$:myVar}' });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual('myVar');
 
-    const result7 = parser.parse<ShorthandTokenExpression>({ source: "$:user['name'].length" });
-    expect(result6).toBeInstanceOf(ShorthandTokenExpression);
-    expect(result7.expression).toEqual("$:user['name'].length");
-    expect(result7.options.name).toEqual('user');
-    expect(result7.options.properties).toEqual([
+    result = parser.parse<FunctionTokenExpression>({ source: '$:journey.version' });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual('journey.version');
+    expect(result.isFunction()).toEqual(true);
+    expect(result.stringify()).toEqual('journey.version');
+    expect(result.options.name).toEqual('journey');
+    expect(result.options.properties).toEqual([new ShorthandTokenExpression({ expression: 'version' })]);
+
+    result = parser.parse<FunctionTokenExpression>({ source: "$:user['name'].length" });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual("user['name'].length");
+    expect(result.isFunction()).toEqual(true);
+    expect(result.stringify()).toEqual("user['name'].length");
+    expect(result.options.name).toEqual('user');
+    expect(result.options.properties).toEqual([
       new ConstantTokenExpression({ expression: 'name', isComputed: true }),
       new ShorthandTokenExpression({ expression: 'length' })
     ]);
 
-    const result8 = parser.parse({ source: '$:null' });
-    expect(result8).toBeInstanceOf(FunctionTokenExpression);
-    expect(result8.expression).toEqual('null');
+    result = parser.parse({ source: '$:null' });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual('null');
 
-    const result9 = parser.parse({ source: '$:true' });
-    expect(result9).toBeInstanceOf(FunctionTokenExpression);
-    expect(result9.expression).toEqual('true');
+    result = parser.parse({ source: '$:true' });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual('true');
 
-    const result10 = parser.parse({ source: '$:(showIf() || false)' });
-    expect(result10).toBeInstanceOf(FunctionTokenExpression);
-    expect(result10.expression).toEqual('showIf() || false');
-    expect(result10.stringify()).toEqual('(function(left, right) { return left || right; })(showIf(), false)');
+    result = parser.parse({ source: '$:(showIf() || false)' });
+    expect(result).toBeInstanceOf(FunctionTokenExpression);
+    expect(result.expression).toEqual('showIf() || false');
+    expect(result.stringify()).toEqual('(function(left, right) { return left || right; })(showIf(), false)');
   });
 
   it('should parse FunctionTokenExpression with arguments', ({ parser }) => {

--- a/journeyapps-evaluator/tests/FormatString.test.ts
+++ b/journeyapps-evaluator/tests/FormatString.test.ts
@@ -89,6 +89,16 @@ describe('FormatString', () => {
     expect(result.tokens[1].start).toEqual(6);
 
     result = FormatString.fromTokens([
+      new ConstantTokenExpression({ expression: 'Hello ' }),
+      new FunctionTokenExpression({
+        name: 'js_variable',
+        expression: 'js_variable.property',
+        properties: [new ShorthandTokenExpression({ expression: 'property' })]
+      })
+    ]);
+    expect(result.expression).toEqual('Hello {$:js_variable.property}');
+
+    result = FormatString.fromTokens([
       new FunctionTokenExpression({
         expression: "foo('bar')",
         arguments: [new ConstantTokenExpression({ expression: 'bar' })]
@@ -108,14 +118,13 @@ describe('FormatString', () => {
     it('from JS/TS member expression ', () => {
       let result = FormatString.compile('{$:journey.runtime.version}');
       expect(result).toEqual([
-        new ShorthandTokenExpression({
-          expression: '$:journey.runtime.version',
+        new FunctionTokenExpression({
+          expression: 'journey.runtime.version',
           name: 'journey',
           properties: [
             new ShorthandTokenExpression({ expression: 'runtime' }),
             new ShorthandTokenExpression({ expression: 'version' })
           ],
-          isFunction: true,
           start: 0
         })
       ]);

--- a/journeyapps-evaluator/tests/FormatString.test.ts
+++ b/journeyapps-evaluator/tests/FormatString.test.ts
@@ -32,7 +32,12 @@ describe('FormatString', () => {
 
   it('should compile ShorthandTokenExpressions', () => {
     expect(FormatString.compile('{person.name}')).toEqual([
-      new ShorthandTokenExpression({ expression: 'person.name', start: 0 })
+      new ShorthandTokenExpression({
+        expression: 'person.name',
+        name: 'person',
+        start: 0,
+        properties: [new ShorthandTokenExpression({ expression: 'name' })]
+      })
     ]);
   });
 
@@ -49,7 +54,13 @@ describe('FormatString', () => {
       new ConstantTokenExpression({ expression: '{some text} more ', start: 0 }),
       new ShorthandTokenExpression({ expression: 'serial', start: 19 }),
       new ConstantTokenExpression({ expression: ' ', start: 27 }),
-      new FormatShorthandTokenExpression({ expression: 'something.other', format: '.2f', start: 28 }),
+      new FormatShorthandTokenExpression({
+        expression: 'something.other',
+        name: 'something',
+        format: '.2f',
+        properties: [new ShorthandTokenExpression({ expression: 'other' })],
+        start: 28
+      }),
       new ConstantTokenExpression({ expression: ' ', start: 49 }),
       new FunctionTokenExpression({
         expression: 'foo("bar")',
@@ -96,9 +107,18 @@ describe('FormatString', () => {
   describe('should compile FunctionTokenExpression', () => {
     it('from JS/TS member expression ', () => {
       let result = FormatString.compile('{$:journey.runtime.version}');
-      expect(result).toEqual([new FunctionTokenExpression({ expression: 'journey.runtime.version', start: 0 })]);
-
-      expect(result[0].isShorthand()).toEqual(false);
+      expect(result).toEqual([
+        new ShorthandTokenExpression({
+          expression: 'journey.runtime.version',
+          name: 'journey',
+          properties: [
+            new ShorthandTokenExpression({ expression: 'runtime' }),
+            new ShorthandTokenExpression({ expression: 'version' })
+          ],
+          isFunction: true,
+          start: 0
+        })
+      ]);
 
       expect(FormatString.compile('{$:true}')).toEqual([new FunctionTokenExpression({ expression: 'true', start: 0 })]);
     });
@@ -223,7 +243,12 @@ describe('FormatString', () => {
       ]);
 
       expect(FormatString.compile('{person.name} {$:foo()}')).toEqual([
-        new ShorthandTokenExpression({ expression: 'person.name', start: 0 }),
+        new ShorthandTokenExpression({
+          expression: 'person.name',
+          name: 'person',
+          properties: [new ShorthandTokenExpression({ expression: 'name' })],
+          start: 0
+        }),
         new ConstantTokenExpression({ expression: ' ', start: 13 }),
         new FunctionTokenExpression({ expression: 'foo()', arguments: [], start: 14 })
       ]);

--- a/journeyapps-evaluator/tests/FormatString.test.ts
+++ b/journeyapps-evaluator/tests/FormatString.test.ts
@@ -109,7 +109,7 @@ describe('FormatString', () => {
       let result = FormatString.compile('{$:journey.runtime.version}');
       expect(result).toEqual([
         new ShorthandTokenExpression({
-          expression: 'journey.runtime.version',
+          expression: '$:journey.runtime.version',
           name: 'journey',
           properties: [
             new ShorthandTokenExpression({ expression: 'runtime' }),


### PR DESCRIPTION
[ch13541](https://app.shortcut.com/journeyapps/story/13541)

- Improve `ShorthandTokenExpression` and `FunctionTokenExpression` to also parse properties, i.e. `object.property1`, `object['property2']`
- Added `isComputed` to `TokenExpression` options