### PR TITLE
[Fix] Function token expression parsing of `await` expressions 

### DIFF
--- a/.changeset/eight-doors-kneel.md
+++ b/.changeset/eight-doors-kneel.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/evaluator': patch
+---
+
+fix: Parsing AwaitExpression into FunctionTokenExpression and improve error handling in TokenExpressionParser when using Babel parser.

--- a/journeyapps-evaluator/src/TokenExpressionParser.ts
+++ b/journeyapps-evaluator/src/TokenExpressionParser.ts
@@ -81,7 +81,14 @@ export class TokenExpressionParser {
       return this.cache.get(source) as T;
     }
 
-    const { program } = babelParser.parse(source);
+    const { program, errors } = babelParser.parse(source, {
+      errorRecovery: true,
+      allowAwaitOutsideFunction: true,
+      allowReturnOutsideFunction: true
+    });
+    if (errors?.length > 0) {
+      console.warn(`[TokenExpressionParser] Error parsing source: ${source}`, errors);
+    }
     const node = program.body[0] ?? program.directives[0];
     const parsed = this.parseNode({ node, source: source, context: event.context });
     this.cache.set(source, parsed);
@@ -115,7 +122,7 @@ export class TokenExpressionParser {
         return factory.getParser();
       }
     }
-    console.error(`No parser found for node type '${nodeType}'`);
+    console.warn(`[TokenExpressionParser] No parser found for node type '${nodeType}', using FallbackExpressionParser`);
     return new FallbackExpressionParser();
   });
 

--- a/journeyapps-evaluator/src/parsers/ExpressionNodeParser.ts
+++ b/journeyapps-evaluator/src/parsers/ExpressionNodeParser.ts
@@ -1,7 +1,9 @@
 import {
   Directive,
+  AwaitExpression,
   ExpressionStatement,
   isDirective,
+  isAwaitExpression,
   isExpressionStatement,
   isLabeledStatement,
   LabeledStatement,
@@ -23,6 +25,8 @@ export class ExpressionNodeParser extends AbstractExpressionParser<ExpressionTyp
       expression = node.body;
     } else if (isDirective(node)) {
       expression = node.value;
+    } else if (isAwaitExpression(node)) {
+      expression = (node as AwaitExpression).argument;
     } else if (isExpressionStatement(node)) {
       expression = node.expression;
     }
@@ -33,7 +37,7 @@ export class ExpressionNodeParser extends AbstractExpressionParser<ExpressionTyp
 
 export class ExpressionNodeParserFactory extends ExpressionParserFactory<ExpressionNodeParser> {
   constructor() {
-    super(['Directive', 'LabeledStatement', 'ExpressionStatement']);
+    super(['Directive', 'AwaitExpression', 'LabeledStatement', 'ExpressionStatement']);
   }
 
   getParser() {

--- a/journeyapps-evaluator/tests/FunctionTokenExpression.test.ts
+++ b/journeyapps-evaluator/tests/FunctionTokenExpression.test.ts
@@ -66,6 +66,14 @@ describe('FunctionTokenExpression', () => {
     expect(token.stringify()).toEqual("'string'");
   });
 
+  it('should parse $:await foo() expression', () => {
+    const token = FunctionTokenExpression.parse('$:await foo()');
+    expect(token).toBeInstanceOf(FunctionTokenExpression);
+    expect(token.expression).toEqual('foo()');
+    expect(token.isCallExpression()).toEqual(true);
+    expect(token.stringify()).toEqual('foo()');
+  });
+
   it('should parse expression without brackets', () => {
     const token = FunctionTokenExpression.parse('$:foo');
     expect(token).toBeInstanceOf(FunctionTokenExpression);
@@ -107,6 +115,12 @@ describe('FunctionTokenExpression', () => {
 
     it('should return a function token expression', () => {
       const token = functionTokenExpression('$:foo()');
+      expect(token).toBeInstanceOf(FunctionTokenExpression);
+      expect(token.expression).toEqual('foo()');
+    });
+
+    it('should handle await function expression', () => {
+      const token = functionTokenExpression('$:await foo()');
       expect(token).toBeInstanceOf(FunctionTokenExpression);
       expect(token.expression).toEqual('foo()');
     });


### PR DESCRIPTION
- fix: parsing of await expressions into `FuntionTokenExpression`
- Improve error handling of `TokenExpressionParser` when using Babel's parser.

## Checklist
- [x] [ch13798](https://app.shortcut.com/journeyapps/story/13798)
- [x] [Zendesk 35616](https://journeyapps.zendesk.com/agent/tickets/35616)