### PR TITLE
[Chore] Using async syntax in `Batch` and `DatabaseObject`

### DIFF
--- a/journeyapps-evaluator/src/definitions/VariableFormatStringScope.ts
+++ b/journeyapps-evaluator/src/definitions/VariableFormatStringScope.ts
@@ -84,13 +84,13 @@ export class VariableFormatStringScope implements FormatStringScope {
     if (typeof scope._get == 'function') {
       // DatabaseObject
       return scope._get(name);
-    } else {
-      if (typeof scope[name] == 'function') {
-        return scope[name]();
-      } else {
-        return scope[name];
-      }
     }
+
+    if (typeof scope[name] == 'function') {
+      return scope[name]();
+    }
+
+    return scope[name];
   }
 
   static cached(scope: VariableScope, name: string): any {


### PR DESCRIPTION
## Description

Instead of always returning a `Promise.resolve()` for none Promise values, we use `await` instead with the hope that optimization will improve performance.

## Checklist
- [x] Clubhouse ticket [ch13857](https://app.shortcut.com/journeyapps/story/13857)