### PR TITLE
[Fix] `journeyapps/db` missing export

### DIFF
--- a/.changeset/dull-dots-exercise.md
+++ b/.changeset/dull-dots-exercise.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/db': minor
+---
+
+Fix missing browser export for primative types

--- a/journeyapps-db/src/browser.ts
+++ b/journeyapps-db/src/browser.ts
@@ -15,13 +15,14 @@ export * from './credentials/MobileCredentials';
 
 export * from './Schema';
 
+export * from './types/primitives';
+
 export * from './types/Type';
 export * from './types/GenericObject';
 export * from './types/ObjectData';
 export * from './types/ObjectType';
 export * from './types/ArrayType';
 export * from './types/QueryType';
-
 export * from './types/Location';
 export { Attachment } from './types/Attachment';
 


### PR DESCRIPTION
Fix: missing browser export for @journeyapps/db primitive types